### PR TITLE
State restructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,18 @@ env:
     - DOCKER_IMAGE=agileiot/$COMPONENT-armv7l
       VERSIONIST=true
     - DOCKER_IMAGE=agileiot/$COMPONENT-x86_64
-      BASEIMAGE=resin\\/nuc-node:7.2.1
+      BASEIMAGE=resin\\/intel-nuc-node:7.8.0-20170506
 
 before_install:
-  - source <(curl -s https://raw.githubusercontent.com/Agile-IoT/agile-ci-scripts/master/before_install.sh)
+  - source <(curl -s https://raw.githubusercontent.com/Agile-IoT/agile-ci-scripts/master/agile-ci-functions.sh)
+  - cache_load
+  - bootstrap
   - echo "Tagging the build with tag - $DOCKER_TAG"
 
 script:
-  - if [[ -n ${DOCKER_TAG} ]]; then
-      docker build -t $DOCKER_IMAGE:$DOCKER_TAG .;
-    fi
+  - travis_wait 30 docker_build_if_needed
+  - cache_save
 
 after_success:
-  - source <(curl -s https://raw.githubusercontent.com/Agile-IoT/agile-ci-scripts/master/after_success.sh)
+  - docker_push_if_needed
+  - versionist_if_needed

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "eject": "react-scripts eject",
     "version": "versionist"
   },
-  "proxy": "http://agile.local:8080"
+  "proxy": "http://0.0.0.0:8080"
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -126,14 +126,19 @@ export const streamsFetch = (deviceId) => {
   };
 }
 
-// fetch all registered devices
-export const devicesFetch = () => {
+// fetch all registered devices and their streams
+export const devicesAndStreamsFetch = () => {
   return (dispatch) => {
     dispatch(loading(true))
     agile.deviceManager.get()
     .then(devices => {
-      dispatch(action('DEVICES', devices));
+      const deviceMap = {}
+
+      devices.forEach(d => deviceMap[d.deviceId] = d)
+
+      dispatch(action('DEVICES', deviceMap));
       dispatch(loading(false));
+      devices.forEach(d => dispatch(streamsFetch(d.deviceId)));
     })
     .catch(err => {
       errorHandle(err, dispatch)

--- a/src/containers/Device.js
+++ b/src/containers/Device.js
@@ -5,9 +5,22 @@ import { DeviceSummary, Stream } from '../components';
 import { deviceFetch, devicesDelete, streamsFetch, deviceSubscribe, deviceUnsubscribe } from '../actions';
 
 class Device extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      device: this.props.devices[this.props.params.deviceId],
+      streams: this.props.streams[this.props.params.deviceId]
+    }
+  }
+
   componentDidMount() {
-    this.props.deviceFetch(this.props.params.deviceId);
-    this.props.streamsFetch(this.props.params.deviceId);
+    // In case we refresh on this view
+    if(!this.state.device)
+      this.props.deviceFetch(this.props.params.deviceId)
+
+    if(!this.state.streams)
+      this.props.streamsFetch(this.props.params.deviceId)
   }
 
   subscribe(device, streams) {
@@ -31,10 +44,16 @@ class Device extends Component {
   }
 
   componentWillUnmount() {
-    this.unsubscribe(this.props.device);
+    this.unsubscribe(this.state.device);
   }
 
   componentWillReceiveProps(nextProps) {
+    if (!this.state.device)
+      this.setState({device: nextProps.devices[this.props.params.deviceId]})
+    if (!this.state.streams)
+      this.setState({streams: nextProps.streams[this.props.params.deviceId]})
+
+
     // Poll for new readings
     setTimeout(() => {
       this.props.streamsFetch(this.props.params.deviceId);
@@ -58,7 +77,7 @@ class Device extends Component {
   }
 
   render() {
-    const { device, streams } = this.props;
+    const { device, streams } = this.state;
     if (device) {
       return (
         <div>
@@ -81,7 +100,7 @@ class Device extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    device: state.device,
+    devices: state.devices,
     streams: state.streams
   };
 };

--- a/src/containers/Devices.js
+++ b/src/containers/Devices.js
@@ -3,7 +3,7 @@ import { DeviceItem } from '../components';
 import { FlatButton } from 'material-ui';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
-import { devicesFetch, devicesDelete } from '../actions';
+import { devicesAndStreamsFetch, devicesDelete } from '../actions';
 
 class Devices extends Component {
 
@@ -20,7 +20,9 @@ class Devices extends Component {
 
   renderItems(devices) {
     if (devices) {
-      return devices.map((device, i) => {
+      return Object.keys(devices).map((deviceId, i) => {
+        const device = devices[deviceId]
+
         return(
           <DeviceItem
             expandable
@@ -37,7 +39,7 @@ class Devices extends Component {
   }
 
   componentDidMount() {
-    this.props.devicesFetch()
+    this.props.devicesAndStreamsFetch()
   }
 
   render() {
@@ -57,7 +59,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    devicesFetch: () => dispatch(devicesFetch()),
+    devicesAndStreamsFetch: () => dispatch(devicesAndStreamsFetch()),
     devicesDelete: (deviceId) => dispatch(devicesDelete(deviceId)),
   };
 };

--- a/src/containers/Discover.js
+++ b/src/containers/Discover.js
@@ -3,6 +3,7 @@ import { DeviceItem } from '../components';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import { connect } from 'react-redux';
+import difference from 'lodash/difference'
 
 import { devicesDiscover, devicesCreate, deviceTypesFetch } from '../actions';
 
@@ -59,26 +60,31 @@ class Discover extends Component {
     }
   }
 
-  componentDidMount() {
-    this.props.devicesDiscover();
-    this.props.devices.map((device) => {
+  updateDeviceTypes(devices) {
+    // fetch list of all available device's
+    devices.map((device) => {
       return this.props.deviceTypesFetch(device)
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    // get new deviceTypes if there are new devices
-    const { devices } = nextProps
-    if (devices.length > this.props.devices.length) {
-      devices.map((device) => {
-        return this.props.deviceTypesFetch(device)
-      });
-    }
+  componentDidMount() {
+    this.props.devicesDiscover();
 
-    // Poll for new devices
-    setTimeout(() => {
-      this.props.devicesDiscover()
+    this.poller = setInterval(() => {
+      this.props.devicesDiscover();
     }, 7000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.poller);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { devices } = nextProps;
+    const newDevices = difference(devices, this.props.devices);
+    if (newDevices) {
+      this.updateDeviceTypes(newDevices);
+    }
   }
 
   render() {

--- a/src/containers/MessageBar.js
+++ b/src/containers/MessageBar.js
@@ -21,7 +21,7 @@ const MessageBar = (props) => {
   // return snack bar if message exists
   const hasMessages = messages.length > 0
   const latestMessage = messages[messages.length - 1]
-  console.log({latestMessage})
+  
   if (hasMessages) {
     setTimeout(() => {
       messageRemove(latestMessage)

--- a/src/reducers/entities.js
+++ b/src/reducers/entities.js
@@ -1,16 +1,23 @@
 import sortBy from 'lodash/sortBy';
+import omit from 'lodash/omit';
 
-export function devices(state = [], action) {
+export function devices(state = {}, action) {
   switch (action.type) {
+    case 'DEVICE':
+      return {
+        ...state,
+        [action.data.deviceId] : action.data
+      }
     case 'DEVICES':
       return action.data;
     case 'DEVICES_DELETE':
-      return state.filter(element => element.deviceId !== action.data);
+      return omit(state, action.data)
     case 'DEVICES_CREATE':
-      return [
-        action.data,
-        ...state
-      ]
+      return {
+        ...state,
+        [action.data.deviceId] : action.data
+      }
+
     default:
       return state;
   }
@@ -89,20 +96,6 @@ export function deviceTypes(state = {}, action) {
         };
       }
       return state
-    default:
-      return state;
-  }
-}
-
-export function device(state = {}, action) {
-  switch (action.type) {
-    case 'DEVICE':
-      return action.data
-    case 'DEVICES_DELETE':
-      if (state.deviceId === action.data) {
-        return {}
-      }
-      return state;
     default:
       return state;
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,7 +8,6 @@ import {
   drawer,
   protocols,
   deviceTypes,
-  device,
   streams
 } from './entities';
 
@@ -21,6 +20,5 @@ export default combineReducers({
     drawer,
     protocols,
     deviceTypes,
-    device,
     streams
 });


### PR DESCRIPTION
Improvements suggested in #33.

1. The `device` state entry was removed in favor of filtering `devices`
2. The `devices` entry was changed from `[device, device, device]` to 
```
{
  deviceId: {device},
  deviceId: {device},
  ...
}
```
This allows us to do some operations in constant time (i.e `this.setState({device: devices[this.props.params.deviceId]})` instead of having to use `devices.find(d => d.deviceId === this.props.params.deviceId)`).
This also allows us to updated an individual device entry easier.

This is an initial version, would be really happy to get feedback, and can easily add modifications if required..