### PR TITLE
Add sub policies and removed dummy lock types

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -605,64 +605,17 @@ export const entityCreateByType = (data, type) => {
 }
 
 export const fetchLocks = () => {
-  /*TODO Lock format does not exist
-  actionExecutedLessThan: {
-   arity: 2,
-   descr: 'This lock ensures that the user attempting an action or accessing ' +
-   'an attribute has not executed an action more than a certain number of times. This lock ' +
-   'uses the audit mechanisms, which log security critical actions',
-   name: 'action execute less than',
-   args: [
-     'action',
-     'count'
-   ]
- },
- timePeriodLock: {
-   arity: 2,
-   descr: 'This lock evaluates to true when the current time lies within an ' +
-   'interval between a starting and end time of the day.',
-   name: 'Time interval',
-   args: [
-     'startTime',
-     'endTime'
-     ]
- },*/
-  const locks = {
-    hasType: {
-      arity: 1,
-      descr: 'This lock validates that an entity has a particular type. This ensures, for ' +
-      'example, that the action performing or on which the action is being performed is of ' +
-      'type "user"',
-      name: 'has type',
-      args: [
-        'type'
-      ]
-    },
-    attrEq: {
-      scopes: ['/device', '/client', '/gateway'],
-      arity: 2,
-      descr: 'This lock is open iff the entity to which this lock is applied to is tagged with the specified attibute which was defined in the specified group and whose value is equal to the specified value.',
-      name: 'attr is eq',
-      args: [
-        'attr',
-        'value'
-      ]
-    },
-    isOwner: {
-      scopes: ['/client', '/device', '/gateway'],
-      arity: 1,
-      descr: 'This lock allows us to ensure that the entity on which the action is being ' +
-      'performed is owned by the entity performing the action on it. This ensures that users ' +
-      'creating entities have the right to read or write some attributes according to our ' +
-      'default security model.',
-      name: 'owns'
-    }
-  }
-  return (dispatch) => {
-    dispatch(loading(true));
-    dispatch(action('LOCK_FORMATS', locks));
-    dispatch(loading(false));
-  }
+	return (dispatch) => {
+		dispatch(loading(true))
+		agile.idm.entity.getEntitiesSchema()
+		.then((schemas) => {
+			dispatch(action('LOCK_FORMATS', schemas.ui["/entity"].locks));
+			dispatch(loading(false));
+		}).catch(err => {
+			errorHandle(err, dispatch)
+		});
+	}
+
 }
 
 export const fetchEntityLocks = (entity_id, entity_type, field) => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -605,17 +605,16 @@ export const entityCreateByType = (data, type) => {
 }
 
 export const fetchLocks = () => {
-	return (dispatch) => {
-		dispatch(loading(true))
-		agile.idm.entity.getEntitiesSchema()
-		.then((schemas) => {
-			dispatch(action('LOCK_FORMATS', schemas.ui.locks));
-			dispatch(loading(false));
-		}).catch(err => {
-			errorHandle(err, dispatch)
-		});
-	}
-
+  return (dispatch) => {
+    dispatch(loading(true))
+    agile.idm.entity.getEntitiesSchema()
+    .then((schemas) => {
+      dispatch(action('LOCK_FORMATS', schemas.ui.locks));
+      dispatch(loading(false));
+    }).catch(err => {
+      errorHandle(err, dispatch)
+    });
+  }
 }
 
 export const fetchEntityLocks = (entity_id, entity_type, field) => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -609,7 +609,7 @@ export const fetchLocks = () => {
 		dispatch(loading(true))
 		agile.idm.entity.getEntitiesSchema()
 		.then((schemas) => {
-			dispatch(action('LOCK_FORMATS', schemas.ui["/entity"].locks));
+			dispatch(action('LOCK_FORMATS', schemas.ui.locks));
 			dispatch(loading(false));
 		}).catch(err => {
 			errorHandle(err, dispatch)

--- a/src/containers/Locks.js
+++ b/src/containers/Locks.js
@@ -52,51 +52,53 @@ class Locks extends Component {
     )
   }
 
-	addNewPolicy(ref, field, id, type) {
-		var newLockName = this.refs[ref].input.value
-    if(newLockName && newLockName !== '') {
-			this.props.setLock({
-				entityId: id,
-				entityType: type,
-				field: field + "." + newLockName,
-				policy: []
-			})
-			this.refs[ref].input.value = '';
-		}
-	}
+  addNewPolicy(ref, field, id, type) {
+    var newLockName = this.refs[ref].input.value
+    if (newLockName && newLockName !== '') {
+      this.props.setLock({
+        entityId: id,
+        entityType: type,
+        field: field + "." + newLockName,
+        policy: []
+      })
+      this.refs[ref].input.value = '';
+    }
+  }
 
-	renderAddPolicyButton(field) {
-		const {id, type} = this.props.params
+  renderAddPolicyButton(field) {
+    const {id, type} = this.props.params
 
-		return (
-			<GenericListItem
+    return (
+      <GenericListItem
         style={{rightEl: {padding: '20px'}, leftEl: {padding: '20px'}}}
-				leftEl='New sub policy'
-				rightEl={
-				  <div>
+        leftEl='New sub policy'
+        rightEl={
+          <div>
             <TextField
-							ref={`addPolicy_${id}_${type}_${field}`}
+              ref={`addPolicy_${id}_${type}_${field}`}
               hintText='Name of new policy'/>
-              <span
-						  id={`add_${id}_${field}`}
-						  key={`${id}_${field}`}
-							style={{
-								float: 'right',
-								position: 'initial',
-								fontWeight: 'bold',
-								width: '10%',
-								color: '#008714',
+            <span
+              id={`add_${id}_${field}`}
+              key={`${id}_${field}`}
+              style={{
+                float: 'right',
+                position: 'initial',
+                fontWeight: 'bold',
+                width: '10%',
+                color: '#008714',
                 padding: '8px'
-							}}
-							onClick={event => {this.addNewPolicy(`addPolicy_${id}_${type}_${field}`, field, id, type) }}
-						>
+              }}
+              onClick={event => {
+                this.addNewPolicy(`addPolicy_${id}_${type}_${field}`, field, id, type)
+              }}
+            >
             ADD NEW
             </span>
           </div>
-				}
-			/>
-		)
-	}
+        }
+      />
+    )
+  }
 
   renderDeleteButton(field) {
     const {id, type} = this.props.params

--- a/src/containers/Locks.js
+++ b/src/containers/Locks.js
@@ -54,13 +54,15 @@ class Locks extends Component {
 
 	addNewPolicy(ref, field, id, type) {
 		var newLockName = this.refs[ref].input.value
-		this.props.setLock({
-			entityId: id,
-			entityType: type,
-			field: field + "." + newLockName,
-			policy: []
-		})
-		this.refs[ref].input.value = '';
+    if(newLockName && newLockName !== '') {
+			this.props.setLock({
+				entityId: id,
+				entityType: type,
+				field: field + "." + newLockName,
+				policy: []
+			})
+			this.refs[ref].input.value = '';
+		}
 	}
 
 	renderAddPolicyButton(field) {
@@ -68,21 +70,28 @@ class Locks extends Component {
 
 		return (
 			<GenericListItem
-				leftEl='New sub policy name'
+        style={{rightEl: {padding: '20px'}, leftEl: {padding: '20px'}}}
+				leftEl='New sub policy'
 				rightEl={
 				  <div>
             <TextField
 							ref={`addPolicy_${id}_${type}_${field}`}
               hintText='Name of new policy'/>
-            <FloatingActionButton
-            mini={true}
-            id={`add_${id}_${field}`}
-            key={`${id}_${field}`}
-            label='Add'
-            style={deleteButtonStyle}
-            onClick={() => {this.addNewPolicy(`addPolicy_${id}_${type}_${field}`, field, id, type)}}>
-             <ContentAdd/>
-            </FloatingActionButton>
+              <span
+						  id={`add_${id}_${field}`}
+						  key={`${id}_${field}`}
+							style={{
+								float: 'right',
+								position: 'initial',
+								fontWeight: 'bold',
+								width: '10%',
+								color: '#008714',
+                padding: '8px'
+							}}
+							onClick={event => {this.addNewPolicy(`addPolicy_${id}_${type}_${field}`, field, id, type) }}
+						>
+            ADD NEW
+            </span>
           </div>
 				}
 			/>

--- a/src/containers/Locks.js
+++ b/src/containers/Locks.js
@@ -12,9 +12,11 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {Link} from 'react-router'
 import {FloatingActionButton, FlatButton} from 'material-ui'
+import TextField from 'material-ui/TextField'
 import ContentRemove from 'material-ui/svg-icons/content/remove'
+import ContentAdd from 'material-ui/svg-icons/content/add'
 import {fetchEntityLocks, deleteLock, setLock} from '../actions'
-import {LockItem} from '../components'
+import {LockItem, GenericListItem} from '../components'
 
 const deleteButtonStyle = {
   margin: 0,
@@ -28,8 +30,8 @@ class Locks extends Component {
     const {id, type} =this.props.params
 
     return (
-      <Link 
-        key={`addread_${field}`} 
+      <Link
+        key={`addwrite_${field}`}
         to={`/lock/add/${id}/${type}/${field}/write`}
       >
         <FlatButton label={`Add write lock`}/>
@@ -41,14 +43,51 @@ class Locks extends Component {
     const {id, type} = this.props.params
 
     return (
-      <Link 
-        key={`addwrite_${field}`} 
+      <Link
+        key={`addread_${field}`}
         to={`/lock/add/${id}/${type}/${field}/read`}
       >
         <FlatButton label={`Add read lock`}/>
       </Link>
     )
   }
+
+	addNewPolicy(ref, field, id, type) {
+		var newLockName = this.refs[ref].input.value
+		this.props.setLock({
+			entityId: id,
+			entityType: type,
+			field: field + "." + newLockName,
+			policy: []
+		})
+		this.refs[ref].input.value = '';
+	}
+
+	renderAddPolicyButton(field) {
+		const {id, type} = this.props.params
+
+		return (
+			<GenericListItem
+				leftEl='New sub policy name'
+				rightEl={
+				  <div>
+            <TextField
+							ref={`addPolicy_${id}_${type}_${field}`}
+              hintText='Name of new policy'/>
+            <FloatingActionButton
+            mini={true}
+            id={`add_${id}_${field}`}
+            key={`${id}_${field}`}
+            label='Add'
+            style={deleteButtonStyle}
+            onClick={() => {this.addNewPolicy(`addPolicy_${id}_${type}_${field}`, field, id, type)}}>
+             <ContentAdd/>
+            </FloatingActionButton>
+          </div>
+				}
+			/>
+		)
+	}
 
   renderDeleteButton(field) {
     const {id, type} = this.props.params
@@ -71,7 +110,7 @@ class Locks extends Component {
   renderBlockDeleteButton(field, i) {
     const {id, type} = this.props.params
     return (
-      <FloatingActionButton 
+      <FloatingActionButton
         mini={true}
         id={`delete_${id}_${field}_${i}`}
         key={`${id}_${field}_${i}`}
@@ -104,7 +143,7 @@ class Locks extends Component {
   renderLockDeleteButton(field, i, j) {
     const {id, type} = this.props.params
     return (
-      <FloatingActionButton 
+      <FloatingActionButton
         mini={true}
         id={`delete_${id}_${field}_${i}_{j}`}
         key={`${id}_${field}_${i}_${j}`}
@@ -145,12 +184,14 @@ class Locks extends Component {
   renderButtons() {
     const result= {}
     const {policies} = this.props
+		console.log(policies);
     for (let policy in policies) {
       result[policy] = policies[policy]
       result[policy].buttons = [
         this.renderDeleteButton(policy),
         this.renderAddWriteLockButton(policy),
-        this.renderAddReadLockButton(policy)
+        this.renderAddReadLockButton(policy),
+        this.renderAddPolicyButton(policy)
       ]
       result[policy].flows.forEach(this.deleteButtons.bind(this, policy))
     }

--- a/src/containers/Locks.js
+++ b/src/containers/Locks.js
@@ -195,7 +195,6 @@ class Locks extends Component {
   renderButtons() {
     const result= {}
     const {policies} = this.props
-		console.log(policies);
     for (let policy in policies) {
       result[policy] = policies[policy]
       result[policy].buttons = [

--- a/src/containers/Nav.js
+++ b/src/containers/Nav.js
@@ -25,12 +25,12 @@ class Nav extends Component {
   }
 
   getTabs() {
-    if (this.props.schemas.schema) {
+    if (this.props.schemas.schema && this.props.schemas.ui && this.props.schemas.ui.entities) {
       return this.props.schemas.schema.filter(schema => {
-        const ui = this.props.schemas.ui && this.props.schemas.ui[schema.id] ? this.props.schemas.ui[schema.id] : {};
+        const ui = this.props.schemas.ui.entities[schema.id] ? this.props.schemas.ui.entities[schema.id] : {};
         return !ui.hidden;
       }).map(schema => {
-        const ui = this.props.schemas.ui && this.props.schemas.ui[schema.id] ? this.props.schemas.ui[schema.id] : {};
+        const ui = this.props.schemas.ui.entities[schema.id] ? this.props.schemas.ui.entities[schema.id] : {};
         return (
           <Tab key={schema.id}
                label={ui.name ? ui.name : schema.id}


### PR DESCRIPTION
Adds the functionality to add sub policies to existing policies (e.g. actions -> actions.newpolicy). Furthermore, we removed the dummy lock types, such that they are fetched from the configuration file.

This PR needs agile-security:v3.6.0, since the UI configuration file changed in agile-security and we had to adjust the UI. 

